### PR TITLE
Make Dockerfile less terrifying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux \
 		unzip \
 # Get Terraform by a specific version
 	; if [ "${TF_VERSION}" = "latest" ]; then \
-		VERSION="$( curl -sS https://releases.hashicorp.com/terraform/ | cat \
+		VERSION="$( curl -sS -L https://releases.hashicorp.com/terraform/ | cat \
 			| grep -Eo '/[.0-9]+/' | grep -Eo '[.0-9]+' \
 			| sort -V | tail -1 )" \
 	else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,12 +132,11 @@ RUN set -eux \
   ; if [ "${AWS}" == "yes" ]; then python3 -m pip install boto3 --no-cache-dir; python3 -m pip install awscli --no-cache-dir; fi \
 #  && if [ "${GCP}" == "yes" ]; then echo GCP; fi \
 #  && if [ "${AZURE}" == "yes" ]; then echo AZURE; fi \
-  ; cat > "${HOME}"/.gitconfig <<EOF \
-[url "https://github.com/"] \
-      insteadOf = git+ssh://github.com/ \
-[url "https://github.com/"] \
-      insteadOf = git@github.com: \
-  EOF
+  ; printf '%s\n' '[url "https://github.com/"]' \
+        'insteadOf = git+ssh://github.com/' \
+	'[url "https://github.com/"]' \
+	'insteadOf = git@github.com:' \ 
+	> "${HOME}/.gitconfig" \
   ; rm -rf /var/cache/* \
   ; rm -rf /root/.cache/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux \
 		unzip \
 # Get Terraform by a specific version
 	; if [ "${TF_VERSION}" = "latest" ]; then \
-		VERSION="$( curl -sS -L https://releases.hashicorp.com/terraform/ | cat \
+		VERSION="$( curl -sS -L https://releases.hashicorp.com/terraform/ \
 			| grep -Eo '/[.0-9]+/' | grep -Eo '[.0-9]+' \
 			| sort -V | tail -1 )" \
 	else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,55 +6,55 @@ ARG TG_VERSION=latest
 
 # Install build dependencies on builder
 RUN set -eux \
-	&& DEBIAN_FRONTEND=noninteractive apt-get update -qq \
-	&& DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
+	; export DEBIAN_FRONTEND=noninteractive
+	; apt-get update -qq \
+	; apt-get install -qq -y --no-install-recommends --no-install-suggests \
 		ca-certificates \
 		curl \
 		git \
 		unzip \
-	&& rm -rf /var/lib/apt/lists/* \
 # Get Terraform by a specific version
-	&& if [ "${TF_VERSION}" = "latest" ]; then \
+	; if [ "${TF_VERSION}" = "latest" ]; then \
 		VERSION="$( curl -sS https://releases.hashicorp.com/terraform/ | cat \
 			| grep -Eo '/[.0-9]+/' | grep -Eo '[.0-9]+' \
-			| sort -V | tail -1 )"; \
+			| sort -V | tail -1 )" \
 	else \
 		VERSION="${TF_VERSION}"; \
 	fi \
-	&& curl -sS -L -O \
+	; curl -sS -L -O \
 		https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip \
-	&& unzip terraform_${VERSION}_linux_amd64.zip \
-	&& mv terraform /usr/bin/terraform \
-	&& chmod +x /usr/bin/terraform \
+	; unzip terraform_${VERSION}_linux_amd64.zip \
+	; mv terraform /usr/bin/terraform \
+	; chmod +x /usr/bin/terraform \
 # Get Terragrunt by a specific version
-	&& git clone https://github.com/gruntwork-io/terragrunt /terragrunt \
-	&& cd /terragrunt \
-	&& if [ "${TG_VERSION}" = "latest" ]; then \
+	; git clone https://github.com/gruntwork-io/terragrunt /terragrunt \
+	; cd /terragrunt \
+	; if [ "${TG_VERSION}" = "latest" ]; then \
 		VERSION="$( git describe --abbrev=0 --tags )"; \
 	else \
 		VERSION="v${TG_VERSION}";\
 	fi \
-	&& curl -sS -L \
+	; curl -sS -L \
 		https://github.com/gruntwork-io/terragrunt/releases/download/${VERSION}/terragrunt_linux_amd64 \
 		-o /usr/bin/terragrunt \
-	&& chmod +x /usr/bin/terragrunt \
+	; chmod +x /usr/bin/terragrunt \
 # Get latest TFLint
-	&& curl -L "$( curl -Ls https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip" )" \
+	; curl -L "$( curl -Ls https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip" )" \
     -o tflint.zip \
-	&& unzip tflint.zip \
-	&& mv tflint /usr/bin/tflint \
-  && chmod +x /usr/bin/tflint \
+	; unzip tflint.zip \
+	; mv tflint /usr/bin/tflint \
+	; chmod +x /usr/bin/tflint \
 # Get latest hcledit
-  && curl -L "$( curl -Ls https://api.github.com/repos/minamijoyo/hcledit/releases/latest | grep -o -E "https://.+?_linux_amd64.tar.gz" )" \
+  ; curl -L "$( curl -Ls https://api.github.com/repos/minamijoyo/hcledit/releases/latest | grep -o -E "https://.+?_linux_amd64.tar.gz" )" \
     -o hcledit.tar.gz \
-  && tar -xf hcledit.tar.gz \
-  && mv hcledit /usr/bin/hcledit \
-  && chmod +x /usr/bin/hcledit \
-  && chown $(id -u):$(id -g) /usr/bin/hcledit \
+  ; tar -xf hcledit.tar.gz \
+  ; mv hcledit /usr/bin/hcledit \
+  ; chmod +x /usr/bin/hcledit \ 
+  ; chown $(id -u):$(id -g) /usr/bin/hcledit \
 # Get latest sops
-	&& curl -L "$( curl -Ls https://api.github.com/repos/mozilla/sops/releases/latest | grep -o -E "https://.+?\.linux" )" \
+	; curl -sS -L "$( curl -Ls https://api.github.com/repos/mozilla/sops/releases/latest | grep -o -E "https://.+?\.linux" )" \
     -o /usr/bin/sops \
-  && chmod +x /usr/bin/sops
+  ; chmod +x /usr/bin/sops
 
 # Use a clean tiny image to store artifacts in
 FROM alpine:3.11
@@ -110,33 +110,36 @@ RUN set -eux \
   && apk update --no-cache \
   && apk upgrade --no-cache \
   && apk add --no-cache bash \
-  && apk add --no-cache curl \
-  && apk add --no-cache docker \
-  && apk add --no-cache git \
-  && apk add --no-cache jq \
-  && apk add --no-cache make \
-  && apk add --no-cache ncurses \
-  && apk add --no-cache openssh \
-  && apk add --no-cache openssl \
-  && apk add --no-cache python3 \
-  && apk add --no-cache zip \
-  && if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi \
-  && python3 -m ensurepip \
-  && rm -r /usr/lib/python*/ensurepip \
-  && pip3 install --no-cache --upgrade pip setuptools wheel \
-  && if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
-  && python3 -m pip install ply --no-cache-dir \
-  && python3 -m pip install pyhcl --no-cache-dir \
-  && python3 -m pip install requests --no-cache-dir \
-  && python3 -m pip install slack_sdk --no-cache-dir \
-  && if [ "${AWS}" == "yes" ]; then python3 -m pip install boto3 --no-cache-dir; python3 -m pip install awscli --no-cache-dir; fi \
+	curl \
+	docker \
+	git \
+	jq \
+	make \
+	ncurses \
+	openssh \
+	openssl \
+	python3 \
+	zip \
+  ; if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi \
+  ; python3 -m ensurepip \
+  ; rm -r /usr/lib/python*/ensurepip \
+  ; pip3 install --no-cache --upgrade pip setuptools wheel \
+  ; if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
+  ; python3 -m pip install --no-cache-dir ply \
+  	pyhcl \
+	requests \
+	slack_sdk \
+  ; if [ "${AWS}" == "yes" ]; then python3 -m pip install boto3 --no-cache-dir; python3 -m pip install awscli --no-cache-dir; fi \
 #  && if [ "${GCP}" == "yes" ]; then echo GCP; fi \
 #  && if [ "${AZURE}" == "yes" ]; then echo AZURE; fi \
-  && mkdir -m 700 /root/.ssh \
-  && touch -m 600 /root/.ssh/known_hosts \
-  && ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts \
-  && rm -rf /var/cache/* \
-  && rm -rf /root/.cache/*
+  ; cat > "${HOME}"/.gitconfig <<EOF \
+[url "https://github.com/"] \
+      insteadOf = git+ssh://github.com/ \
+[url "https://github.com/"] \
+      insteadOf = git@github.com: \
+  EOF
+  ; rm -rf /var/cache/* \
+  ; rm -rf /root/.cache/*
 
 WORKDIR /data
 CMD terraform --version && terragrunt --version


### PR DESCRIPTION
* you already use `set -uex`, no need for `&&`
* git should not use ssh in first place, use inseadOf command to rewrite ssh, the known hosts/tofu method is insecure
* use same curl flags across the build
* avoid repetitive calls of apk add and pip install
* removing unnecessary removing of apt-mirror-cache since it's in the builder step
* the latest feature for terraform was broken, is that build method even in use?

### Brief description:

I just reviewed the `Dockerfile`, it's odd.

I don't see why one would use Debian-slim for retrieving the artifacts, you can almost 1:1 use the same Dockerimage for both steps.

Overall I'd advice rather to introduce docker-image layering instead of relying on the builder. Each curl installation should be a separate layer.
