### PR TITLE
Fixed: GCP executables not on PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,9 +117,10 @@ RUN if [ "${GCP}" = "yes" ]; then \
       gnupg~=2.2.31 ;\
     curl https://sdk.cloud.google.com > /tmp/install.sh ;\
     bash /tmp/install.sh --disable-prompts --install-dir=/ ;\
+    for f in $(find /google-cloud-sdk/bin -maxdepth 1 -executable -type f); do \
+      ln -s $f /usr/local/bin/$(basename $f); done ;\
     echo ". /google-cloud-sdk/completion.bash.inc" >> /root/.profile ;\
     echo ". /google-cloud-sdk/path.bash.inc" >> /root/.profile ;\
-    source /root/.profile ;\
     gcloud config set core/disable_usage_reporting true ;\
     gcloud config set component_manager/disable_update_check true ;\
     gcloud config set metrics/environment github_docker_image ;\


### PR DESCRIPTION
## :memo:  Symlink to Google Cloud SDK executables in `/usr/local/bin`

<!-- Write you description here -->

In `Dockerfile`, whenever GCP is enabled, create symlinks to executables in `/google-cloud-sdk/bin` in `/usr/local/bin` so that these executables will always be on `PATH`, regardless of whether the user is `root` or not or whether the user has sourced a profile file. This fixes #509 .

## :computer:  Commits
<!-- Diff commits - START -->
`fc1c98af` - Matthew Smedberg - `Tue Nov 2 23:00:21 2021 -0600`
Fixed: GCP executables not on PATH
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
`Dockerfile`
<!-- Diff files - END -->


## :warning: Additional information
* [ ] Pushed to a branch with a proper name and provided proper commit message.
* [ ] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
