### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ ARG TG_VERSION=latest
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 RUN if [ "${TG_VERSION}" = "latest" ]; then \
   VERSION="$( curl -LsS https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest \
-    | jq -r .name  | sed 's|v||' )" ;\
+    | jq -r .name )" ;\
   else \
     VERSION="v${TG_VERSION}" ;\
   fi ;\


### PR DESCRIPTION
fix TG $VERSION when TG_VERSION=latest in Dockerfile, was missing "v" in front of version number

## :memo:  Brief description

<!-- Write you description here -->

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [ ] Pushed to a branch with a proper name and provided proper commit message.
* [ ] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
