### PR TITLE
Fix format-hcl by removing quotes around flags passed to terraform and tofu

### DIFF
--- a/fmt/format-hcl
+++ b/fmt/format-hcl
@@ -78,10 +78,10 @@ HCL_RET_CODE=$?
 
 echo -e "\n=> Searching for .tf and .tfvars files"
 if command -v terraform &> /dev/null; then
-  terraform fmt "${LIST}" "${WRITE}" "${DIFF}" "${CHECK}" "${RECURSIVE}" "$@"
+  terraform fmt ${LIST} ${WRITE} ${DIFF} ${CHECK} ${RECURSIVE} "$@"
   TF_RET_CODE=$?
 elif command -v tofu &> /dev/null; then
-  tofu fmt "${LIST}" "${WRITE}" "${DIFF}" "${CHECK}" "${RECURSIVE}" "$@"
+  tofu fmt ${LIST} ${WRITE} ${DIFF} ${CHECK} ${RECURSIVE} "$@"
   TF_RET_CODE=$?
 else
   echo "Neither terraform nor opentofu (tofu) is installed."


### PR DESCRIPTION
## :memo:  Brief description

This PR attempts to fix the `format-hcl` script by removing the quotes around the parameters introduced in https://github.com/devops-infra/docker-terragrunt/commit/d29d43a81ddb417f289854f33ac616ab97e00fd6

Fixes #2559

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [x] Pushed to a branch with a proper name and provided proper commit message.
* [x] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
